### PR TITLE
enable result paging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+.Renviron

--- a/R/gie_aggregate.R
+++ b/R/gie_aggregate.R
@@ -28,7 +28,7 @@
 #'   labs(title = "End of June Gas Storage")
 #' }
 #'
-gie_gas_aggregate <- function(area, api_key = NULL){
+gie_gas_aggregate <- function(area, api_key = NULL, ...){
 
   area <- tolower(area)
 
@@ -36,27 +36,11 @@ gie_gas_aggregate <- function(area, api_key = NULL){
     stop("Area only accepts 'eu' or 'ne' and not both.")
   }
 
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
-
   url <- paste0("https://agsi.gie.eu/api/data/", area)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
+  cont_df <- gie_internal_page_request(url, api_key, ...)
 
-  if(httr::status_code(resp) != 200){
-    status_httr <- httr::http_status(resp)
-    stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
-
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
-
-  cont_df <- jsonlite::fromJSON(cont)
-
-  if(length(cont_df) == 0){
+  if(nrow(cont_df) == 0){
     stop("No data for this area.")
   }
 
@@ -104,35 +88,31 @@ gie_gas_aggregate <- function(area, api_key = NULL){
 #'   labs(title = "End of June Gas Storage")
 #' }
 #'
-gie_lng_aggregate <- function(area, api_key = NULL){
+gie_lng_aggregate <- function(area, api_key = NULL, ...){
 
   area <- tolower(area)
 
   if(!area %in% c("ne", "eu") & length(area) > 1){
     stop("Area only accepts 'eu' or 'ne' and not both.")
   }
-
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
+  api_key <- Sys.getenv("GIE_PAT")
 
   url <- paste0("https://alsi.gie.eu/api/data/", area)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
+  resp <- httr::GET(url = url, httr::add_headers("x-key" = api_key))
 
   if(httr::status_code(resp) != 200){
     status_httr <- httr::http_status(resp)
     stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
+                   "Reason:", status_httr$reason,
+                  "Message:", status_httr$message))
+}
 
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
+cont <- httr::content(resp, as = "text", encoding = "UTF-8")
 
-  cont_df <- jsonlite::fromJSON(cont)
+cont_df <- jsonlite::fromJSON(cont)
 
-  if(length(cont_df) == 0){
+  if(nrow(cont_df) == 0){
     stop("No data for this area.")
   }
 

--- a/R/gie_company_eic.R
+++ b/R/gie_company_eic.R
@@ -5,11 +5,12 @@
 #' @param eic_company_code The 21 digit eic code of the company as found on the API page.
 #' @param api_key The default is NULL and searches for your GIE_PAT in you .Renviron
 #'     file.
+#' @param ... Forwarded to [gie_internal_page_request()]
 #'
 #' @export
 #'
 #'
-gie_gas_company_eic <- function(country_code, eic_code, eic_company_code, api_key = NULL){
+gie_gas_company_eic <- function(country_code, eic_code, eic_company_code, api_key = NULL, ...){
 
   area <- toupper(country_code)
 
@@ -17,27 +18,12 @@ gie_gas_company_eic <- function(country_code, eic_code, eic_company_code, api_ke
     stop("country_code only accepts a vector of length one.")
   }
 
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
 
   url <- paste0("https://agsi.gie.eu/api/data/", eic_code, "/", country_code, "/", eic_company_code)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
+  cont_df <- gie_internal_page_request(url, api_key, ...)
 
-  if(httr::status_code(resp) != 200){
-    status_httr <- httr::http_status(resp)
-    stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
-
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
-
-  cont_df <- jsonlite::fromJSON(cont)
-
-  if(length(cont_df) == 0){
+  if(nrow(cont_df) == 0){
     stop("No data with these parameters.")
   }
 
@@ -75,7 +61,7 @@ gie_gas_company_eic <- function(country_code, eic_code, eic_company_code, api_ke
 #'
 #' }
 #'
-gie_lng_company_eic <- function(country_code, eic_code, eic_company_code, api_key = NULL){
+gie_lng_company_eic <- function(country_code, eic_code, eic_company_code, api_key = NULL, ...){
 
   area <- toupper(country_code)
 
@@ -83,27 +69,12 @@ gie_lng_company_eic <- function(country_code, eic_code, eic_company_code, api_ke
     stop("country_code only accepts a vector of length one.")
   }
 
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
 
   url <- paste0("https://alsi.gie.eu/api/data/", eic_code, "/", country_code, "/", eic_company_code)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
+  cont_df <- gie_internal_page_request(url, api_key, ...)
 
-  if(httr::status_code(resp) != 200){
-    status_httr <- httr::http_status(resp)
-    stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
-
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
-
-  cont_df <- jsonlite::fromJSON(cont)
-
-  if(length(cont_df) == 0){
+  if(nrow(cont_df) == 0){
     stop("No data with these parameters.")
   }
 

--- a/R/gie_country.R
+++ b/R/gie_country.R
@@ -15,7 +15,7 @@
 #'
 #' }
 #'
-gie_gas_country <- function(country_code, api_key = NULL){
+gie_gas_country <- function(country_code, api_key = NULL, ...){
 
   area <- toupper(country_code)
 
@@ -23,30 +23,16 @@ gie_gas_country <- function(country_code, api_key = NULL){
     stop("country_code only accepts a vector of length one.")
   }
 
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
 
   url <- paste0("https://agsi.gie.eu/api/data/", country_code)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
 
-  if(httr::status_code(resp) != 200){
-    status_httr <- httr::http_status(resp)
-    stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
 
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
+  cont_df <- gie_internal_page_request(url, api_key, ...)
 
-  cont_df <- jsonlite::fromJSON(cont)
-
-  if(length(cont_df) == 0){
+  if(nrow(cont_obj) == 0){
     stop("No data for this country.")
   }
-
   cont_df$info <- sapply(cont_df$info, function(x){
     if(length(x) < 1){
       x <- as.character(NA)
@@ -77,7 +63,7 @@ gie_gas_country <- function(country_code, api_key = NULL){
 #'
 #' }
 #'
-gie_lng_country <- function(country_code, api_key = NULL){
+gie_lng_country <- function(country_code, api_key = NULL, ...){
 
   area <- toupper(country_code)
 
@@ -85,27 +71,12 @@ gie_lng_country <- function(country_code, api_key = NULL){
     stop("country_code only accepts a vector of length one.")
   }
 
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
 
   url <- paste0("https://alsi.gie.eu/api/data/", country_code)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
+  cont_df <- gie_internal_page_request(url, api_key, ...)
 
-  if(httr::status_code(resp) != 200){
-    status_httr <- httr::http_status(resp)
-    stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
-
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
-
-  cont_df <- jsonlite::fromJSON(cont)
-
-  if(length(cont_df) == 0){
+  if(nrow(cont_df) == 0){
     stop("No data for this country.")
   }
   cont_df$info <- sapply(cont_df$info, function(x){

--- a/R/gie_eic.R
+++ b/R/gie_eic.R
@@ -14,7 +14,7 @@
 #'
 #' head(gie_gas_eic("AT", "25X-GSALLC-----E"))
 #'
-gie_gas_eic <- function(country_code, eic_code, api_key = NULL){
+gie_gas_eic <- function(country_code, eic_code, api_key = NULL, ...){
 
   area <- toupper(country_code)
 
@@ -22,27 +22,12 @@ gie_gas_eic <- function(country_code, eic_code, api_key = NULL){
     stop("country_code only accepts a vector of length one.")
   }
 
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
 
   url <- paste0("https://agsi.gie.eu/api/data/", eic_code, "/", country_code)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
+  cont_df <- gie_internal_page_request(url, api_key, ...)
 
-  if(httr::status_code(resp) != 200){
-    status_httr <- httr::http_status(resp)
-    stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
-
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
-
-  cont_df <- jsonlite::fromJSON(cont)
-
-  if(length(cont_df) == 0){
+  if(nrow(cont_df) == 0){
     stop("No data with these parameters.")
   }
 
@@ -70,7 +55,7 @@ gie_gas_eic <- function(country_code, eic_code, api_key = NULL){
 #' @export
 #'
 #'
-gie_lng_eic <- function(country_code, eic_code, api_key = NULL){
+gie_lng_eic <- function(country_code, eic_code, api_key = NULL, ...){
 
   area <- toupper(country_code)
 
@@ -78,27 +63,12 @@ gie_lng_eic <- function(country_code, eic_code, api_key = NULL){
     stop("country_code only accepts a vector of length one.")
   }
 
-  if(is.null(api_key)){
-    api_key <- Sys.getenv("GIE_PAT")
-  }
 
   url <- paste0("https://alsi.gie.eu/api/data/", eic_code, "/", country_code)
 
-  resp <- httr::GET(url = url,
-                    httr::add_headers("x-key" = api_key))
+  cont_df <- gie_internal_page_request(url, api_key, ...)
 
-  if(httr::status_code(resp) != 200){
-    status_httr <- httr::http_status(resp)
-    stop(paste("Category:", status_httr$category,
-               "Reason:", status_httr$reason,
-               "Message:", status_httr$message))
-  }
-
-  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
-
-  cont_df <- jsonlite::fromJSON(cont)
-
-  if(length(cont_df) == 0){
+  if(nrow(cont_df) == 0){
     stop("No data with these parameters.")
   }
 

--- a/R/gie_internal_page_request.R
+++ b/R/gie_internal_page_request.R
@@ -1,0 +1,69 @@
+#' Get the historical data export for for a specific facility from a company within a country.
+#'
+#' @param url The base URL to request
+#' @param api_key The default is NULL and searches for your GIE_PAT in you .Renviron
+#'     file.
+#' @param max_pages Page results if possible, up to this number of pages.
+#'     Both a message and a warning are emitted if there are more pages
+#'     than this parameter specifies.
+gie_internal_page_request <- function(url, api_key, max_pages=10) {
+
+  if(is.null(api_key)){
+    api_key <- Sys.getenv("GIE_PAT")
+  }
+
+
+  resp <- httr::GET(url = url,
+                    httr::add_headers("x-key" = api_key))
+
+  if(httr::status_code(resp) != 200){
+    status_httr <- httr::http_status(resp)
+    stop(paste("Category:", status_httr$category,
+               "Reason:", status_httr$reason,
+               "Message:", status_httr$message))
+  }
+
+  cont <- httr::content(resp, as = "text", encoding = "UTF-8")
+
+  cont_obj <- jsonlite::fromJSON(cont)
+
+  cont_df <- cont_obj$data
+
+  page <- 1
+
+  if(cont_obj$last_page>max_pages) {
+    w <- paste0(
+        'Only returning ', max_pages, ' of ', cont_obj$last_page, ' pages. ',
+        'Add max_pages parameter to load more data'
+      )
+    message(w)
+    warning(w)
+  }
+
+  while(page<cont_obj$last_page && page<max_pages) {
+    page <- page + 1
+
+    url <- paste0("https://agsi.gie.eu/api/data/", country_code, "?page=", page)
+
+    resp <- httr::GET(url = url,
+                      httr::add_headers("x-key" = api_key))
+
+    if(httr::status_code(resp) != 200){
+      status_httr <- httr::http_status(resp)
+      stop(paste("Category:", status_httr$category,
+                 "Reason:", status_httr$reason,
+                 "Message:", status_httr$message))
+    }
+
+    cont <- httr::content(resp, as = "text", encoding = "UTF-8")
+
+    cont_obj <- jsonlite::fromJSON(cont)
+
+    cont_df <- cont_df %>%
+      bind_rows(cont_obj$data)
+
+    Sys.sleep(0.5)
+  }
+
+  cont_df
+}

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ gie R Package
 gie is an R package for wrapping the Gas Infrastructure Europe (GIE)
 REST API.
 
-## API Key
+This version is adapted to the recent (as of 2022) API version that returns
+partial results, requiring paging.
 
-The official documentation from GIE can be found
-[here](https://agsi.gie.eu/GIE_API_documentation_v003.pdf)
+## API Key
 
 Before proceeding with the examples you need to get a token / API key
 from the [GIE homepage](https://agsi.gie.eu/#/api). On the API page you


### PR DESCRIPTION
This adapts most `gie` functions to the new API with paging results. I have explicitly tested the `gie_gas_country` and `gie_gas_company_eic` functions, some others (like `gie_aggregate` do not seem to work with the current URLs).

This is also built in a black-box kind of way, since the API documentation seems down. Happy to discuss.